### PR TITLE
Remove evidence panel, network labels, and webhook sim button

### DIFF
--- a/apps/web/components/mev-forensics/App.tsx
+++ b/apps/web/components/mev-forensics/App.tsx
@@ -5,12 +5,9 @@ import { INVESTIGATIONS, TRADES } from "@/lib/sample-data";
 import { Header } from "./Header";
 import { TradesSidebar } from "./sidebar/TradesSidebar";
 import { InvestigationCanvas } from "./canvas/InvestigationCanvas";
-import { EvidencePanel } from "./evidence/EvidencePanel";
-import { WebhookToast } from "./WebhookToast";
 
 export function App() {
   const [selectedId, setSelectedId] = useState<string>("tx1");
-  const [showToast, setShowToast]   = useState(false);
   // Sync initial state from DOM — the no-flash script in layout.tsx already
   // applied the correct theme before hydration.
   const [dark, setDark] = useState(() => {
@@ -38,7 +35,6 @@ export function App() {
       <Header
         dark={dark}
         onToggleDark={() => setDark((d) => !d)}
-        onSimulateWebhook={() => setShowToast(true)}
       />
 
       <div className="flex-1 flex overflow-hidden">
@@ -52,13 +48,7 @@ export function App() {
           investigation={selectedInv}
           onFollowUp={(q) => console.log("follow up:", q)}
         />
-        <EvidencePanel
-          trade={selectedTrade}
-          investigation={selectedInv}
-        />
       </div>
-
-      {showToast && <WebhookToast onDismiss={() => setShowToast(false)} />}
     </div>
   );
 }

--- a/apps/web/components/mev-forensics/Header.tsx
+++ b/apps/web/components/mev-forensics/Header.tsx
@@ -5,10 +5,9 @@ import { LogoIcon, MoonIcon, SunIcon } from "./primitives/icons";
 interface Props {
   dark: boolean;
   onToggleDark: () => void;
-  onSimulateWebhook: () => void;
 }
 
-export function Header({ dark, onToggleDark, onSimulateWebhook }: Props) {
+export function Header({ dark, onToggleDark }: Props) {
   return (
     <header className="h-11 shrink-0 bg-surface border-b border-border-s flex items-center px-5 gap-3">
       {/* Logo */}
@@ -21,21 +20,7 @@ export function Header({ dark, onToggleDark, onSimulateWebhook }: Props) {
         </span>
       </div>
 
-      <div className="w-px h-4 bg-border-s" />
-
-      <span className="text-xs text-text-t">Ethereum mainnet</span>
-      <span className="text-border-d text-xs">·</span>
-      <span className="text-xs text-text-t">Uniswap v2 / v3</span>
-
       <div className="flex-1" />
-
-      <button
-        type="button"
-        onClick={onSimulateWebhook}
-        className="px-2.5 py-1 bg-transparent border border-border-d rounded text-[11px] text-text-s cursor-pointer mr-1.5 hover:bg-sunken transition-colors"
-      >
-        Simulate webhook
-      </button>
 
       <button
         type="button"

--- a/claude.md
+++ b/claude.md
@@ -33,7 +33,7 @@ Both paths feed into the exact same investigation pipeline.
 | Tenderly | REST via plain `fetch` | No official SDK needed — just typed fetch wrappers |
 | Claude model | `claude-sonnet-4-6` | Best tool-use reliability |
 | Server | Hono | Native SSE streaming — critical for live tool-call timeline |
-| Frontend | Next.js 14 App Router + TailwindCSS | Three-column dashboard — Trade list / Chat+Timeline / Evidence panel |
+| Frontend | Next.js 14 App Router + TailwindCSS | Two-column dashboard — Trade list / Chat+Timeline |
 | Icons | Lucide Icons v0.475+ | Stroke-only, 1.5px weight, 16×20px — no emoji, no custom SVGs |
 | Design tokens | `mev-forensics-design-system/` | Forensic Warm palette, Inter + JetBrains Mono, CSS vars in `colors_and_type.css` |
 | Streaming | SSE (Server-Sent Events) | Live tool-call timeline from Hono → Next.js |
@@ -240,7 +240,7 @@ GET  /wallets                 → list registered wallet addresses
 
 ---
 
-## Frontend layout (3-column dashboard)
+## Frontend layout (2-column dashboard)
 
 **Design source of truth:** `mev-forensics-design-system/project/README.md` + `ui_kits/app/index.html` — Forensic Warm palette, design tokens in `colors_and_type.css`.
 
@@ -261,18 +261,7 @@ GET  /wallets                 → list registered wallet addresses
 - Chat input at bottom with tx hash paste support
 - Narrative: clickable citation chips `[tool_call_3]` that scroll to and highlight the source tool call
 
-**Right (~340px) — Evidence panel**
-- Verdict card: green (frontrun confirmed) / amber (unknown) / gray (normal) — tinted background at ~8% opacity
-- PnL tiles: Expected | Realized | Gap — USD-annotated, signed (`+$25.40`, `-$25.40`)
-- Gap card shows both threshold indicators (Δ>5% and Δ>$10) as check/cross icons
-- Unknown verdict: expandable audit trail showing hypotheses investigated + what ruled each out
-- Citation cards: one per tool result — key fields only, no raw JSON
-- Actor rows with role badges (arbitrageur / victim / liquidator / builder / pool / receiver / flash_loan_provider)
-- Toggle: Actors view (net PnL per actor) ↔ Timeline view (chronological call order)
-- Hover on any address: tooltip with full address + Etherscan external-link icon
-- Clears only when a new trade is selected
-
-**Mobile breakpoint:** Columns collapse into tabs (Trades / Investigation / Evidence) — never stacked.
+**Mobile breakpoint:** Columns collapse into tabs (Trades / Investigation) — never stacked.
 
 **Dark mode:** Token-based, toggle in header. Contrast-checked — frontrun and unknown cards use adjusted backgrounds to maintain WCAG AA readability.
 


### PR DESCRIPTION
Closes #48

## Changes

- **`App.tsx`** — removed `EvidencePanel` and `WebhookToast` from the layout; layout is now two-column (sidebar + canvas)
- **`Header.tsx`** — removed "Ethereum mainnet" / "Uniswap v2 / v3" labels and the "Simulate webhook" button; dropped `onSimulateWebhook` prop entirely
- **`CLAUDE.md`** — updated frontend layout description from 3-column to 2-column; removed Evidence Panel spec section

## Test plan

- [ ] Header shows only logo + dark mode toggle — no network labels, no simulate button
- [ ] Layout is sidebar + investigation canvas only — no right panel
- [ ] Dark mode toggle still works
- [ ] No TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)