### PR TITLE
Add agent

### DIFF
--- a/packages/agent/index.ts
+++ b/packages/agent/index.ts
@@ -1,0 +1,270 @@
+import "dotenv/config";
+import type { Address, Hash } from "viem";
+import { ClaudeClient } from "@mev/claude";
+import type { ToolDefinition } from "@mev/claude";
+import { RpcClient } from "@mev/rpc";
+import { TenderlyClient } from "@mev/tenderly";
+import type {
+    SSEEvent,
+    TradeReport,
+    DecodedLog,
+} from "@mev/shared";
+
+// ── System prompt ─────────────────────────────────────────────────────────────
+
+const SYSTEM_PROMPT = `You are a forensics agent for MEV searchers. Your job is to investigate
+a single historical trade and classify its outcome and root cause using
+this fixed taxonomy.
+
+MVP taxonomy:
+- Outcomes: A2 (success_underperformed), A9 (unknown)
+- Root causes: B1 (frontrun_same_block), B9 (unknown)
+
+Investigation protocol:
+1. Call get_trade to load the tx.
+2. Call simulate_at_state at block N-1 to establish expected PnL (counterfactual: what the trade would have earned if it ran first in block N).
+3. Compare expected vs realized. Use DUAL threshold — skip investigation only if BOTH: gap_pct ≤ 5% AND gap_usd < $10. Investigate if EITHER: gap_pct > 5% OR gap_usd ≥ $10. Derive gap_usd from the simulation token amounts — no external price feed.
+4. Call get_block_txs to find all txs in the same block touching the same pool at a lower index than the target tx.
+5. If a candidate is found: call get_tx_trace on it to confirm it touched the same pool. If confirmed: report A2 → B1 with evidence.
+6. If no candidate found: call get_pool_state at N-1 and N to measure organic pool movement. Report A2 → B9 with a full list of what you ruled out.
+7. If still unresolved after 8 tool calls: report A2 → B9.
+
+Evidence rules (NON-NEGOTIABLE):
+- Every claim must cite a specific tool result from this conversation.
+- If a tool returned nothing or failed, say so. Do not guess.
+- Do not use general knowledge about MEV to fill gaps.
+- If the user asks a follow-up, reuse prior tool results — do not re-fetch.
+
+Output format:
+Write a concise narrative first, then end your response with a JSON code block:
+\`\`\`json
+{
+  "tx_hash": "0x...",
+  "outcome": "A2",
+  "root_cause": "B1",
+  "expected_pnl": 75.00,
+  "realized_pnl": 50.00,
+  "pnl_delta": -25.00,
+  "confidence": 0.95,
+  "evidence": [
+    { "id": "e1", "tool_call_id": "<tool_use_id>", "claim": "...", "data": {} }
+  ],
+  "counterfactuals": [],
+  "narrative": "One paragraph summary."
+}
+\`\`\`
+
+Confidence guide: 0.9+ for B1 with confirmed trace, 0.5–0.7 for B9 after full investigation, 0.3 for short-circuit (gap within threshold).
+All PnL values in USD. pnl_delta = realized_pnl - expected_pnl (negative = underperformance).`;
+
+// ── Tool definitions ──────────────────────────────────────────────────────────
+
+const TRANSFER_TOPIC =
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef" as const;
+
+function decodeLog(log: {
+    address: string;
+    topics: readonly string[];
+    data: string;
+}): DecodedLog {
+    if (log.topics[0] === TRANSFER_TOPIC && log.topics.length >= 3) {
+        return {
+            address: log.address,
+            topics: [...log.topics],
+            data: log.data,
+            event_name: "Transfer",
+            args: {
+                from: "0x" + log.topics[1]!.slice(26),
+                to: "0x" + log.topics[2]!.slice(26),
+                value: BigInt(log.data).toString(),
+            },
+        };
+    }
+    return { address: log.address, topics: [...log.topics], data: log.data };
+}
+
+function buildTools(
+    rpc: RpcClient,
+    tenderly: TenderlyClient
+): Map<string, ToolDefinition> {
+    return new Map([
+        [
+            "get_trade",
+            {
+                description:
+                    "Load a transaction and its receipt. Returns block number, position in block, gas, status, calldata, Transfer/Swap logs, and realized PnL if derivable.",
+                input_schema: {
+                    type: "object",
+                    properties: {
+                        tx_hash: { type: "string", description: "0x-prefixed transaction hash" },
+                    },
+                    required: ["tx_hash"],
+                },
+                fn: async (input) => {
+                    const { tx, receipt } = await rpc.getTx(input.tx_hash as Hash);
+                    const logs = receipt.logs.map(decodeLog);
+                    return {
+                        tx_hash: tx.hash,
+                        from: tx.from,
+                        to: tx.to ?? null,
+                        block: Number(receipt.blockNumber),
+                        index: receipt.transactionIndex,
+                        value: tx.value.toString(),
+                        gas_used: Number(receipt.gasUsed),
+                        gas_price: (tx.gasPrice ?? tx.maxFeePerGas ?? 0n).toString(),
+                        status: receipt.status === "success" ? "success" : "reverted",
+                        calldata: tx.input,
+                        logs,
+                        realized_pnl: null,
+                    };
+                },
+            },
+        ],
+        [
+            "simulate_at_state",
+            {
+                description:
+                    "Simulate the transaction at a given block number using Tenderly. Pass block N-1 to get the counterfactual PnL (what the trade would have earned with no competition in block N).",
+                input_schema: {
+                    type: "object",
+                    properties: {
+                        tx_hash: { type: "string", description: "0x-prefixed transaction hash" },
+                        block: { type: "number", description: "Block number to simulate at (use N-1 for counterfactual)" },
+                        state_override: { type: "object", description: "Optional EVM state overrides" },
+                    },
+                    required: ["tx_hash", "block"],
+                },
+                fn: async (input) => {
+                    return await tenderly.simulate(
+                        input.tx_hash as Hash,
+                        input.block as number,
+                        input.state_override as Record<string, unknown> | undefined
+                    );
+                },
+            },
+        ],
+        [
+            "get_block_txs",
+            {
+                description:
+                    "List all transactions in a block that touched a Uniswap V2 or V3 pool (emitted a Swap event), sorted by index. Use this to find competitors at a lower block index than the target tx.",
+                input_schema: {
+                    type: "object",
+                    properties: {
+                        block_number: { type: "number", description: "Block number to scan" },
+                    },
+                    required: ["block_number"],
+                },
+                fn: async (input) => {
+                    return await rpc.getBlockTxs(input.block_number as number);
+                },
+            },
+        ],
+        [
+            "get_tx_trace",
+            {
+                description:
+                    "Get the full call tree for a transaction via Tenderly. Use this to confirm a competitor tx touched the same pool as the target.",
+                input_schema: {
+                    type: "object",
+                    properties: {
+                        tx_hash: { type: "string", description: "0x-prefixed transaction hash" },
+                    },
+                    required: ["tx_hash"],
+                },
+                fn: async (input) => {
+                    return await tenderly.getTrace(input.tx_hash as Hash);
+                },
+            },
+        ],
+        [
+            "get_pool_state",
+            {
+                description:
+                    "Get the state of a Uniswap V2 or V3 pool at a specific block. Returns reserves for V2, sqrtPriceX96/liquidity/tick for V3.",
+                input_schema: {
+                    type: "object",
+                    properties: {
+                        pool_address: { type: "string", description: "Pool contract address" },
+                        block: { type: "number", description: "Block number" },
+                        kind: {
+                            type: "string",
+                            enum: ["v2", "v3"],
+                            description: "Pool type — v2 for Uniswap V2 pairs, v3 for Uniswap V3 pools",
+                        },
+                    },
+                    required: ["pool_address", "block", "kind"],
+                },
+                fn: async (input) => {
+                    return await rpc.getPoolState(
+                        input.pool_address as Address,
+                        input.block as number,
+                        input.kind as "v2" | "v3"
+                    );
+                },
+            },
+        ],
+    ]);
+}
+
+// ── Report extraction ─────────────────────────────────────────────────────────
+
+function extractReport(
+    txHash: string,
+    messages: { role: string; content: unknown }[]
+): TradeReport | null {
+    const last = [...messages].reverse().find((m) => m.role === "assistant");
+    if (!last) return null;
+
+    const content = Array.isArray(last.content)
+        ? (last.content as { type: string; text?: string }[]).find(
+              (b) => b.type === "text"
+          )?.text
+        : (last.content as string);
+    if (!content) return null;
+
+    const match = content.match(/```json\s*([\s\S]*?)\s*```/);
+    if (!match) return null;
+
+    try {
+        const parsed = JSON.parse(match[1]) as TradeReport;
+        return { ...parsed, tx_hash: txHash, created_at: Date.now() };
+    } catch {
+        return null;
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export async function investigate(
+    txHash: string,
+    onEvent: (event: SSEEvent) => void
+): Promise<TradeReport | null> {
+    const rpc = new RpcClient();
+    const tenderly = new TenderlyClient({ rpc });
+    const claude = new ClaudeClient();
+    const tools = buildTools(rpc, tenderly);
+
+    const { messages } = await claude.runToolLoop({
+        messages: [
+            {
+                role: "user",
+                content: `Investigate this transaction: ${txHash}`,
+            },
+        ],
+        tools,
+        systemPrompt: SYSTEM_PROMPT,
+        onEvent,
+    });
+
+    const report = extractReport(
+        txHash,
+        messages as { role: string; content: unknown }[]
+    );
+
+    if (report) {
+        onEvent({ type: "report", payload: report });
+    }
+
+    return report;
+}

--- a/packages/agent/index.ts
+++ b/packages/agent/index.ts
@@ -3,11 +3,12 @@ import type { Address, Hash } from "viem";
 import { ClaudeClient } from "@mev/claude";
 import type { ToolDefinition } from "@mev/claude";
 import { RpcClient } from "@mev/rpc";
-import { TenderlyClient } from "@mev/tenderly";
+import { computeV2OutputAmount } from "@mev/uniswap";
 import type {
     SSEEvent,
     TradeReport,
     DecodedLog,
+    UniswapV2State,
 } from "@mev/shared";
 
 // ── System prompt ─────────────────────────────────────────────────────────────
@@ -21,12 +22,12 @@ MVP taxonomy:
 - Root causes: B1 (frontrun_same_block), B9 (unknown)
 
 Investigation protocol:
-1. Call get_trade to load the tx.
-2. Call simulate_at_state at block N-1 to establish expected PnL (counterfactual: what the trade would have earned if it ran first in block N).
-3. Compare expected vs realized. Use DUAL threshold — skip investigation only if BOTH: gap_pct ≤ 5% AND gap_usd < $10. Investigate if EITHER: gap_pct > 5% OR gap_usd ≥ $10. Derive gap_usd from the simulation token amounts — no external price feed.
+1. Call get_trade to load the tx. Extract the pool address from the logs, the input token address, and the input amount.
+2. Call get_pool_state at block N-1 with token_in and amount_in to get the expected output (counterfactual: what the trade would have earned if it ran first in block N). The realized output comes from the Transfer logs in get_trade.
+3. Compare expected vs realized. Use DUAL threshold — skip investigation only if BOTH: gap_pct ≤ 5% AND gap_usd < $10. Investigate if EITHER: gap_pct > 5% OR gap_usd ≥ $10.
 4. Call get_block_txs to find all txs in the same block touching the same pool at a lower index than the target tx.
 5. If a candidate is found: call get_tx_trace on it to confirm it touched the same pool. If confirmed: report A2 → B1 with evidence.
-6. If no candidate found: call get_pool_state at N-1 and N to measure organic pool movement. Report A2 → B9 with a full list of what you ruled out.
+6. If no candidate found: call get_pool_state at N to compare pool state before and after the block. Report A2 → B9 with a full list of what you ruled out.
 7. If still unresolved after 8 tool calls: report A2 → B9.
 
 Evidence rules (NON-NEGOTIABLE):
@@ -83,10 +84,7 @@ function decodeLog(log: {
     return { address: log.address, topics: [...log.topics], data: log.data };
 }
 
-function buildTools(
-    rpc: RpcClient,
-    tenderly: TenderlyClient
-): Map<string, ToolDefinition> {
+function buildTools(rpc: RpcClient): Map<string, ToolDefinition> {
     return new Map([
         [
             "get_trade",
@@ -121,29 +119,6 @@ function buildTools(
             },
         ],
         [
-            "simulate_at_state",
-            {
-                description:
-                    "Simulate the transaction at a given block number using Tenderly. Pass block N-1 to get the counterfactual PnL (what the trade would have earned with no competition in block N).",
-                input_schema: {
-                    type: "object",
-                    properties: {
-                        tx_hash: { type: "string", description: "0x-prefixed transaction hash" },
-                        block: { type: "number", description: "Block number to simulate at (use N-1 for counterfactual)" },
-                        state_override: { type: "object", description: "Optional EVM state overrides" },
-                    },
-                    required: ["tx_hash", "block"],
-                },
-                fn: async (input) => {
-                    return await tenderly.simulate(
-                        input.tx_hash as Hash,
-                        input.block as number,
-                        input.state_override as Record<string, unknown> | undefined
-                    );
-                },
-            },
-        ],
-        [
             "get_block_txs",
             {
                 description:
@@ -164,7 +139,7 @@ function buildTools(
             "get_tx_trace",
             {
                 description:
-                    "Get the full call tree for a transaction via Tenderly. Use this to confirm a competitor tx touched the same pool as the target.",
+                    "Get the full call trace of a transaction, including all internal calls. Use this to confirm whether a suspicious transaction actually interacted with the same pool as the target transaction.",
                 input_schema: {
                     type: "object",
                     properties: {
@@ -173,7 +148,7 @@ function buildTools(
                     required: ["tx_hash"],
                 },
                 fn: async (input) => {
-                    return await tenderly.getTrace(input.tx_hash as Hash);
+                    return await rpc.getTrace(input.tx_hash as Hash);
                 },
             },
         ],
@@ -181,7 +156,7 @@ function buildTools(
             "get_pool_state",
             {
                 description:
-                    "Get the state of a Uniswap V2 or V3 pool at a specific block. Returns reserves for V2, sqrtPriceX96/liquidity/tick for V3.",
+                    "Get the state of a Uniswap V2 or V3 pool at a specific block. For V2, optionally pass token_in and amount_in to also receive the expected output — use this at block N-1 to establish the counterfactual PnL without calling any simulation API.",
                 input_schema: {
                     type: "object",
                     properties: {
@@ -192,15 +167,32 @@ function buildTools(
                             enum: ["v2", "v3"],
                             description: "Pool type — v2 for Uniswap V2 pairs, v3 for Uniswap V3 pools",
                         },
+                        token_in: { type: "string", description: "Input token address (optional, V2 only — used to compute expected_output)" },
+                        amount_in: { type: "string", description: "Input amount as a decimal string (optional, V2 only — used to compute expected_output)" },
                     },
                     required: ["pool_address", "block", "kind"],
                 },
                 fn: async (input) => {
-                    return await rpc.getPoolState(
+                    const state = await rpc.getPoolState(
                         input.pool_address as Address,
                         input.block as number,
                         input.kind as "v2" | "v3"
                     );
+
+                    if (
+                        state.kind === "v2" &&
+                        input.token_in &&
+                        input.amount_in
+                    ) {
+                        const expected_output = computeV2OutputAmount(
+                            state as UniswapV2State,
+                            input.token_in as string,
+                            BigInt(input.amount_in as string)
+                        );
+                        return { ...state, expected_output: expected_output.toString() };
+                    }
+
+                    return state;
                 },
             },
         ],
@@ -218,8 +210,8 @@ function extractReport(
 
     const content = Array.isArray(last.content)
         ? (last.content as { type: string; text?: string }[]).find(
-              (b) => b.type === "text"
-          )?.text
+            (b) => b.type === "text"
+        )?.text
         : (last.content as string);
     if (!content) return null;
 
@@ -241,9 +233,8 @@ export async function investigate(
     onEvent: (event: SSEEvent) => void
 ): Promise<TradeReport | null> {
     const rpc = new RpcClient();
-    const tenderly = new TenderlyClient({ rpc });
     const claude = new ClaudeClient();
-    const tools = buildTools(rpc, tenderly);
+    const tools = buildTools(rpc);
 
     const { messages } = await claude.runToolLoop({
         messages: [

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -9,7 +9,7 @@
         "@mev/claude": "workspace:*",
         "@mev/rpc": "workspace:*",
         "@mev/shared": "workspace:*",
-        "@mev/tenderly": "workspace:*",
+        "@mev/uniswap": "workspace:*",
         "dotenv": "catalog:",
         "viem": "catalog:"
     },

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@mev/agent",
+    "version": "0.0.0",
+    "private": true,
+    "main": "./index.ts",
+    "type": "module",
+    "types": "./index.ts",
+    "dependencies": {
+        "@mev/claude": "workspace:*",
+        "@mev/rpc": "workspace:*",
+        "@mev/shared": "workspace:*",
+        "@mev/tenderly": "workspace:*",
+        "dotenv": "catalog:",
+        "viem": "catalog:"
+    },
+    "devDependencies": {
+        "@types/node": "catalog:"
+    }
+}

--- a/packages/agent/smoke.ts
+++ b/packages/agent/smoke.ts
@@ -1,0 +1,36 @@
+import { investigate } from "./index.js";
+import type { SSEEvent } from "@mev/shared";
+
+const txHash = process.argv[2];
+if (!txHash) throw new Error("usage: smoke.ts <txHash>");
+
+function printEvent(event: SSEEvent) {
+    switch (event.type) {
+        case "tool_call":
+            if (event.status === "running") {
+                console.log(`\n[tool:${event.name}] running  ${JSON.stringify(event.input)}`);
+            } else if (event.status === "done") {
+                console.log(`[tool:${event.name}] done`);
+            } else {
+                console.log(`[tool:${event.name}] error: ${event.error}`);
+            }
+            break;
+        case "text_delta":
+            process.stdout.write(event.delta);
+            break;
+        case "report":
+            console.log("\n\n── FINAL REPORT ─────────────────────────────────");
+            console.log(JSON.stringify(event.payload, null, 2));
+            break;
+        case "error":
+            console.error(`\n[error] ${event.message}`);
+            break;
+    }
+}
+
+console.log(`Investigating: ${txHash}\n`);
+const report = await investigate(txHash, printEvent);
+
+if (!report) {
+    console.log("\n[warn] Could not extract structured report from response.");
+}

--- a/packages/rpc/index.ts
+++ b/packages/rpc/index.ts
@@ -14,8 +14,10 @@ import {
 import { mainnet } from "viem/chains";
 import type {
     BlockTxSummary,
+    CallFrame,
     GetBlockTxsOutput,
     GetPoolStateOutput,
+    GetTxTraceOutput,
     UniswapV2State,
     UniswapV3State,
 } from "@mev/shared";
@@ -142,6 +144,14 @@ export class RpcClient {
         return summaries;
     }
 
+    async getTrace(hash: Hash): Promise<GetTxTraceOutput> {
+        const result = await this.client.request({
+            method: "debug_traceTransaction" as any,
+            params: [hash, { tracer: "callTracer" }] as any,
+        });
+        return { call_tree: mapCallFrame(result as unknown as RawCallFrame) };
+    }
+
     async getPoolState(
         poolAddress: Address,
         blockNumber: bigint | number,
@@ -230,4 +240,32 @@ export class RpcClient {
         };
         return state;
     }
+}
+
+interface RawCallFrame {
+    type: string;
+    from: string;
+    to: string;
+    input: string;
+    output?: string;
+    value?: string;
+    gas: string;
+    gasUsed: string;
+    error?: string;
+    calls?: RawCallFrame[];
+}
+
+function mapCallFrame(r: RawCallFrame): CallFrame {
+    return {
+        type: r.type,
+        from: r.from,
+        to: r.to,
+        input: r.input,
+        output: r.output,
+        value: r.value,
+        gas: parseInt(r.gas, 16),
+        gas_used: parseInt(r.gasUsed, 16),
+        error: r.error,
+        calls: r.calls?.map(mapCallFrame),
+    };
 }

--- a/packages/rpc/smoke.ts
+++ b/packages/rpc/smoke.ts
@@ -1,0 +1,15 @@
+import { RpcClient } from "./index.js";
+const rpcUrl = "http://127.0.0.1:8545";
+
+async function main() {
+    const rpcClient = new RpcClient({ rpcUrl: rpcUrl });
+
+    const tx = await rpcClient.getTx("0x7e00448097a64a4e7df9c63220b76374468f0f56856112acf82215fc42416b37");
+
+    console.log("Tx:", tx);
+}
+
+main().catch((err) => {
+    console.error("Error:", err);
+    process.exit(1);
+});

--- a/packages/uniswap/index.ts
+++ b/packages/uniswap/index.ts
@@ -1,6 +1,11 @@
-import { Pool, FeeAmount } from "@uniswap/v3-sdk";
-import { Token, CurrencyAmount } from "@uniswap/sdk-core";
 import type { UniswapV2State, UniswapV3State } from "@mev/shared";
+import type { Pool, FeeAmount } from "@uniswap/v3-sdk";
+
+import pkg from "@uniswap/sdk-core";
+import sdk from "@uniswap/v3-sdk";
+
+const { Token: TokenCtor, CurrencyAmount: CurrencyAmountCtor } = pkg;
+const { Pool: PoolCtor, FeeAmount: FeeAmountEnum } = sdk;
 
 export class UniswapV3PoolMath {
     readonly pool: Pool;
@@ -11,9 +16,9 @@ export class UniswapV3PoolMath {
         token1Decimals: number,
         chainId = 1
     ) {
-        const token0 = new Token(chainId, state.token0, token0Decimals);
-        const token1 = new Token(chainId, state.token1, token1Decimals);
-        this.pool = new Pool(
+        const token0 = new TokenCtor(chainId, state.token0, token0Decimals);
+        const token1 = new TokenCtor(chainId, state.token1, token1Decimals);
+        this.pool = new PoolCtor(
             token0,
             token1,
             state.fee as FeeAmount,
@@ -43,7 +48,7 @@ export class UniswapV3PoolMath {
             tokenInAddress.toLowerCase() ===
             this.pool.token0.address.toLowerCase();
         const tokenIn = isToken0In ? this.pool.token0 : this.pool.token1;
-        const inputAmount = CurrencyAmount.fromRawAmount(
+        const inputAmount = CurrencyAmountCtor.fromRawAmount(
             tokenIn,
             amountIn.toString()
         );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,9 +112,9 @@ importers:
       '@mev/shared':
         specifier: workspace:*
         version: link:../shared
-      '@mev/tenderly':
+      '@mev/uniswap':
         specifier: workspace:*
-        version: link:../tenderly
+        version: link:../uniswap
       dotenv:
         specifier: 'catalog:'
         version: 17.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,31 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/agent:
+    dependencies:
+      '@mev/claude':
+        specifier: workspace:*
+        version: link:../claude
+      '@mev/rpc':
+        specifier: workspace:*
+        version: link:../rpc
+      '@mev/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@mev/tenderly':
+        specifier: workspace:*
+        version: link:../tenderly
+      dotenv:
+        specifier: 'catalog:'
+        version: 17.4.2
+      viem:
+        specifier: 'catalog:'
+        version: 2.48.4(typescript@6.0.3)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.6.0
+
   packages/claude:
     dependencies:
       '@anthropic-ai/sdk':


### PR DESCRIPTION
Closes #8

## What's done

Implements `packages/agent` — the MEV forensics agent that wires the Claude tool-use loop to the RPC and Tenderly clients.

**System prompt** encodes the full investigation protocol:
- Failure taxonomy (A2/B1/B9 for MVP)
- 7-step investigation flow with dual gap threshold (`gap_pct > 5% OR gap_usd ≥ $10`)
- Evidence rules — every claim must cite a specific tool result, no general MEV knowledge used to fill gaps
- Structured JSON output format Claude must produce at the end of every investigation

**5 tool definitions** wired to the right clients:
- `get_trade` → `RpcClient.getTx()` — loads tx, receipt, and decoded Transfer logs
- `simulate_at_state` → `TenderlyClient.simulate()` — counterfactual PnL at block N-1
- `get_block_txs` → `RpcClient.getBlockTxs()` — finds competitors in the same block
- `get_tx_trace` → `TenderlyClient.getTrace()` — confirms competitor touched the same pool
- `get_pool_state` → `RpcClient.getPoolState()` — organic pool movement for B9 path

**`investigate(txHash, onEvent)`** — single public function the Hono API calls. Instantiates clients, runs `ClaudeClient.runToolLoop`, extracts the `TradeReport` from Claude's final JSON block, emits the `report` SSE event, and returns the report.