### PR TITLE
Add investigate route with SSE streaming

### DIFF
--- a/apps/api/data/reports/0x7e00448097a64a4e7df9c63220b76374468f0f56856112acf82215fc42416b37.json
+++ b/apps/api/data/reports/0x7e00448097a64a4e7df9c63220b76374468f0f56856112acf82215fc42416b37.json
@@ -1,0 +1,65 @@
+{
+  "tx_hash": "0x7e00448097a64a4e7df9c63220b76374468f0f56856112acf82215fc42416b37",
+  "outcome": "A2",
+  "root_cause": "B1",
+  "expected_pnl": 495948.08,
+  "realized_pnl": 493427.09,
+  "pnl_delta": -2520.99,
+  "confidence": 0.95,
+  "evidence": [
+    {
+      "id": "e1",
+      "tool_call_id": "get_trade",
+      "claim": "Target tx swapped 200 ETH (200000000000000000000 wei) for USDC on pool 0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc at block 19000004, index 1. Realized USDC output: 493,427,089,116 units ($493,427.09).",
+      "data": {
+        "pool": "0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc",
+        "token_in": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "amount_in": "200000000000000000000",
+        "realized_output_usdc_units": "493427089116",
+        "block": 19000004,
+        "index": 1
+      }
+    },
+    {
+      "id": "e2",
+      "tool_call_id": "get_pool_state",
+      "claim": "At block 19000003 (N-1), simulated output for 200 ETH in was 495,948,078,599 USDC units ($495,948.08) — the counterfactual expected PnL.",
+      "data": {
+        "expected_output": "495948078599",
+        "reserve0_usdc": "48919244487709",
+        "reserve1_weth": "19468984195369336452844"
+      }
+    },
+    {
+      "id": "e3",
+      "tool_call_id": "get_block_txs",
+      "claim": "Block 19000004 contains a tx at index 0 (0x24b879293ff2e838e2f739bc7794cec9a46581c84f6f1414a5463cff1a7f645c) that touched the same pool 0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc before the target tx at index 1.",
+      "data": {
+        "frontrun_tx": "0x24b879293ff2e838e2f739bc7794cec9a46581c84f6f1414a5463cff1a7f645c",
+        "frontrun_index": 0,
+        "target_index": 1,
+        "touched_pool": "0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc"
+      }
+    },
+    {
+      "id": "e4",
+      "tool_call_id": "get_tx_trace",
+      "claim": "Trace of 0x24b879... confirms it called swap() on 0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc via Uniswap V2 Router, sending WETH in and receiving 125,738,181,167 USDC out (0x1d16d3222f), thereby moving the pool price against the target tx.",
+      "data": {
+        "frontrun_from": "0x6a7cc54c4ab51296163ff9e0fa2ed581a69d7a39",
+        "pool_called": "0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc",
+        "usdc_out": "125738181167",
+        "weth_in_wei": "50000000000000000000"
+      }
+    }
+  ],
+  "counterfactuals": [
+    {
+      "description": "If the front-run tx had not executed first, the target tx would have received $495,948.08 in USDC instead of $493,427.09, saving $2,520.99."
+    }
+  ],
+  "narrative": "Transaction 0x7e00448097a6... swapped 200 ETH for USDC on the Uniswap V2 WETH/USDC pool at block 19,000,004 (index 1). A front-runner (0x24b879...45c, index 0) executed an identical ETH→USDC swap on the same pool in the same block just before the target, consuming pool liquidity and pushing the WETH/USDC price against the victim. The pool state at block N-1 shows a counterfactual expected output of $495,948.08, while the target tx only realized $493,427.09 — a loss of $2,520.99 (0.51%). The front-run is confirmed by both get_block_txs (same pool, lower index) and get_tx_trace (direct swap() call on 0xb4e16d... draining ~$125,738 of USDC from the pool beforehand).",
+  "created_at": 1777727035012,
+  "tool_calls": [],
+  "is_auto": false
+}

--- a/apps/api/index.ts
+++ b/apps/api/index.ts
@@ -1,13 +1,17 @@
-import "dotenv/config";
-import { readdir, readFile } from "node:fs/promises";
+import { config } from "dotenv";
+config({ path: new URL("../../.env", import.meta.url).pathname });
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { streamSSE } from "hono/streaming";
+import { investigate } from "@mev/agent";
 import { Outcome, RootCause, TradeVerdict } from "@mev/shared";
 import type {
     GetTradeOutput,
+    SSEEvent,
     TradeListItem,
     TradeReport,
 } from "@mev/shared";
@@ -100,6 +104,32 @@ app.get("/trades/:tx_hash", async (c) => {
     const report = await readReport(tx_hash);
     if (!report) return c.json({ error: "Report not found" }, 404);
     return c.json(report);
+});
+
+app.post("/trades/:tx_hash/investigate", async (c) => {
+    const tx_hash = c.req.param("tx_hash");
+
+    return streamSSE(c, async (stream) => {
+        const onEvent = async (event: SSEEvent) => {
+            await stream.writeSSE({ data: JSON.stringify(event) });
+        };
+
+        try {
+            const report = await investigate(tx_hash, onEvent);
+            if (report) {
+                await mkdir(REPORTS_DIR, { recursive: true });
+                await writeFile(
+                    join(REPORTS_DIR, `${tx_hash}.json`),
+                    JSON.stringify(report, null, 2)
+                );
+            }
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            await stream.writeSSE({
+                data: JSON.stringify({ type: "error", message } satisfies SSEEvent),
+            });
+        }
+    });
 });
 
 const PORT = 3001;

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,6 +9,7 @@
     },
     "dependencies": {
         "@hono/node-server": "catalog:",
+        "@mev/agent": "workspace:*",
         "@mev/shared": "workspace:*",
         "dotenv": "catalog:",
         "hono": "catalog:"

--- a/packages/agent/index.ts
+++ b/packages/agent/index.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import { config } from "dotenv";
+config({ path: new URL("../../.env", import.meta.url).pathname });
 import type { Address, Hash } from "viem";
 import { ClaudeClient } from "@mev/claude";
 import type { ToolDefinition } from "@mev/claude";
@@ -10,6 +11,7 @@ import type {
     DecodedLog,
     UniswapV2State,
 } from "@mev/shared";
+import { extractReport } from "@mev/shared/report.js";
 
 // ── System prompt ─────────────────────────────────────────────────────────────
 
@@ -197,33 +199,6 @@ function buildTools(rpc: RpcClient): Map<string, ToolDefinition> {
             },
         ],
     ]);
-}
-
-// ── Report extraction ─────────────────────────────────────────────────────────
-
-function extractReport(
-    txHash: string,
-    messages: { role: string; content: unknown }[]
-): TradeReport | null {
-    const last = [...messages].reverse().find((m) => m.role === "assistant");
-    if (!last) return null;
-
-    const content = Array.isArray(last.content)
-        ? (last.content as { type: string; text?: string }[]).find(
-            (b) => b.type === "text"
-        )?.text
-        : (last.content as string);
-    if (!content) return null;
-
-    const match = content.match(/```json\s*([\s\S]*?)\s*```/);
-    if (!match) return null;
-
-    try {
-        const parsed = JSON.parse(match[1]) as TradeReport;
-        return { ...parsed, tx_hash: txHash, created_at: Date.now() };
-    } catch {
-        return null;
-    }
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────

--- a/packages/claude/index.ts
+++ b/packages/claude/index.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import { config } from "dotenv";
+config({ path: new URL("../../.env", import.meta.url).pathname });
 import Anthropic from "@anthropic-ai/sdk";
 import type { MessageParam } from "@anthropic-ai/sdk/resources/messages.js";
 import type { SSEEvent, ToolName } from "@mev/shared";

--- a/packages/rpc/index.ts
+++ b/packages/rpc/index.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import { config } from "dotenv";
+config({ path: new URL("../../.env", import.meta.url).pathname });
 import {
     createPublicClient,
     http,

--- a/packages/shared/report.ts
+++ b/packages/shared/report.ts
@@ -1,0 +1,26 @@
+import { TradeReport } from "./index.js";
+
+export function extractReport(
+    txHash: string,
+    messages: { role: string; content: unknown }[]
+): TradeReport | null {
+    const last = [...messages].reverse().find((m) => m.role === "assistant");
+    if (!last) return null;
+
+    const content = Array.isArray(last.content)
+        ? (last.content as { type: string; text?: string }[]).find(
+            (b) => b.type === "text"
+        )?.text
+        : (last.content as string);
+    if (!content) return null;
+
+    const match = content.match(/```json\s*([\s\S]*?)\s*```/);
+    if (!match) return null;
+
+    try {
+        const parsed = JSON.parse(match[1]) as TradeReport;
+        return { ...parsed, tx_hash: txHash, created_at: Date.now(), tool_calls: parsed.tool_calls ?? [], is_auto: parsed.is_auto ?? false };
+    } catch {
+        return null;
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@hono/node-server':
         specifier: 'catalog:'
         version: 2.0.1(hono@4.12.16)
+      '@mev/agent':
+        specifier: workspace:*
+        version: link:../../packages/agent
       '@mev/shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
## What

Implements `POST /trades/:tx_hash/investigate` — the main investigation trigger that streams a live tool-call timeline to the frontend via Server-Sent Events.

Closes #14.

## Changes

**`apps/api`**
- Added `POST /trades/:tx_hash/investigate` using Hono's `streamSSE`. Opens the SSE stream immediately, pipes every `SSEEvent` from the agent's `investigate()` call as `data: <json>` lines, saves the completed `TradeReport` to `data/reports/{tx_hash}.json`, and emits `{ type: "error" }` on failure.
- Added `@mev/agent` as a dependency.

**`packages/agent`**
- Moved `extractReport` into `@mev/shared/report.ts` so it can be reused outside the agent package.
- `extractReport` now fills in `tool_calls: []` and `is_auto: false` as defaults when Claude's JSON block omits them, preventing `extractBlock`/`deriveVerdict` in the API from throwing.

**`packages/shared`**
- Added `report.ts` with the shared `extractReport` utility.

**`packages/claude`, `packages/rpc`**
- Fixed `dotenv` loading to always read from the monorepo root `.env` using an absolute path derived from `import.meta.url`, regardless of which directory the process is started from.

## How to test

### 1. Start Anvil forked from mainnet

```bash
anvil --fork-url $ALCHEMY_RPC_URL --fork-block-number 19000000 --order fees
```

### 2. Point the RPC at your local Anvil node

Add this to your `.env` at the root of the repo (comment out or remove any existing `ALCHEMY_RPC_URL` line):

```
ALCHEMY_RPC_URL=http://127.0.0.1:8545
```

### 3. Simulate a sandwich attack

```bash
pnpm tsx packages/tenderly/sandwich.ts
```

This script funds two EOAs, disables automine, inserts a front-run and a victim swap into the same block, mines the block, then sends the back-run. The victim tx hash is printed to the Anvil console output.

### 4. Run the agent smoke test

```bash
pnpm tsx packages/agent/smoke.ts <victim-tx-hash>
```

### 5. Or hit the API endpoint directly

Start the API server (`pnpm --filter @mev/api dev`), then:

```bash
curl -N -X POST http://localhost:3001/trades/<victim-tx-hash>/investigate
```

The SSE stream should emit `tool_call` and `text_delta` events live, finishing with a `report` event containing an **A2 → B1** verdict (frontrunner confirmed). The report JSON is saved to `apps/api/data/reports/<tx-hash>.json`.